### PR TITLE
Change ContactsAdapter.VH class to static.

### DIFF
--- a/app/src/main/java/com/codepath/android/lollipopexercise/adapters/ContactsAdapter.java
+++ b/app/src/main/java/com/codepath/android/lollipopexercise/adapters/ContactsAdapter.java
@@ -50,7 +50,7 @@ public class ContactsAdapter extends RecyclerView.Adapter<ContactsAdapter.VH> {
     }
 
     // Provide a reference to the views for each contact item
-    public class VH extends RecyclerView.ViewHolder {
+    public static class VH extends RecyclerView.ViewHolder {
         final View rootView;
         final ImageView ivProfile;
         final TextView tvName;


### PR DESCRIPTION
Non-static inner classes are not good practice in general, and whenever the inner class really doesn't need access to its enclosing class object (in this case `ContactsAdapter`), we should make it static.